### PR TITLE
Python3: fixed tests and implementation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        # sudo apt-get -yq install libmysqlclient-dev python3-mysqldb
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
@@ -37,4 +38,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest || true
+        # pytest || true
+        PYTHONPATH=src/ python tests/runtests.py -c tests/pydotest.rc -d "sqlite"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mysqlclient

--- a/src/pydo/__init__.py
+++ b/src/pydo/__init__.py
@@ -29,4 +29,4 @@ __all__=getall('pydo.%s' % m for m in
 del getall
 
 
-__version__='2.0.4'
+__version__='2.0.5'

--- a/src/pydo/dbi.py
+++ b/src/pydo/dbi.py
@@ -289,7 +289,8 @@ def initAlias(alias, driver, connectArgs, pool=None, verbose=False, init=None):
             # get rid of connection for the sake of comparison
             old.pop('connection', None)
             if data!=old:
-                raise ValueError("already initialized: %s" % alias)
+                raise ValueError("already initialized: %s: %r != %r" %
+                                 (alias, data, old))
         else:
             _aliases[alias]=data
     finally:

--- a/src/pydo/drivers/mysqlconn.py
+++ b/src/pydo/drivers/mysqlconn.py
@@ -80,6 +80,13 @@ class MysqlDBI(DBIBase):
         nullableFields=[]
         for row in res:
             name, tipe, nullable, key, default, extra=row
+            if nullable == 'NO':
+                nullable = False
+            elif nullable == 'YES':
+                nullable = True
+            else:
+                raise RuntimeError("%s: unknown `nullable` for column '%s'" %
+                                   (nullable, name))
             if nullable:
                 nullableFields.append(name)
             if (not nullable) and extra=='auto_increment':

--- a/tests/config.py
+++ b/tests/config.py
@@ -15,15 +15,13 @@ from testingtesting import _defaultNamePat
 
 # https://stackoverflow.com/questions/436198/what-is-an-alternative-to-execfile-in-python-3
 def _execfile(cmd, g, l):
-    print("_execfile(%r, %r, %r)" % (cmd, g, l))
     exec(open(cmd).read(), g, l)
 if sys.version_info[0] == 3:
     execfile=_execfile
 
-
-DEFAULT_CONFIG='~/.pydotestrc'
-
-ALLDRIVERS=_driverConfig.keys()
+DEFAULT_CONFIG = '~/.pydotestrc'
+ALLDRIVERS = _driverConfig.keys()
+DRIVER = None
 
 def _readConfigFile(fname=DEFAULT_CONFIG):
     fname=os.path.expanduser(fname)
@@ -73,7 +71,7 @@ def readCmdLine(args, usage=None):
                       default=False)
     opts, args=parser.parse_args(args)
     try:
-        c=_readConfigFile(opts.config)
+        c = _readConfigFile(opts.config)
     except:
         traceback.print_exc()
         parser.error("error reading config file!")
@@ -93,18 +91,17 @@ def readCmdLine(args, usage=None):
     retdrivers={}
     # init all the aliases
     for d in drivers:
-        try:
-            connectArgs=c[d]
-        except:
+        if not d in c:
             print("no config for driver: %s" % d, file=sys.stderr)
         else:
+            connectArgs=c[d]
             connectArgs['driver']=d
             if opts.verbose is not None:
                 connectArgs['verbose']=opts.verbose
             # the connection alias will always be "pydotest"
-            connectArgs['alias']='pydotest'
             if not isinstance(connectArgs, dict):
                 parser.error("configuration error: must be a dict, got a %s" % type(connectArgs))
+            connectArgs['alias']='pydotest'
             retdrivers[d]=connectArgs
 
     if opts.pattern:
@@ -116,5 +113,4 @@ def readCmdLine(args, usage=None):
         pat=_defaultNamePat
 
     return retdrivers, tags, pat, opts.unittest
-
 

--- a/tests/fixture.py
+++ b/tests/fixture.py
@@ -1,12 +1,18 @@
 from pydo.dbi import getConnection
 import pydo as P
 import config
+import sys
 
-def get_sequence_sql():
-    return dict(sqlite='INTEGER PRIMARY KEY NOT NULL',
+
+_SEQ_COL_SQL = dict(sqlite='INTEGER PRIMARY KEY NOT NULL',
                 sqlite2='INTEGER PRIMARY KEY NOT NULL',
                 psycopg='SERIAL PRIMARY KEY',
-                mysql='INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY')[config.DRIVER]
+                mysql='INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY')
+
+def get_sequence_sql():
+    if config.DRIVER not in _SEQ_COL_SQL:
+        raise KeyError("%r: incorect value of config.DRIVER" % config.DRIVER)
+    return _SEQ_COL_SQL[config.DRIVER]
 
 
 class Fixture(object):
@@ -199,7 +205,7 @@ class base_fixture(Fixture):
         #
         # sqlite2 transactions won't rollback table creation; only data
         #
-        if self.db.autocommit or config.DRIVER == "sqlite2":
+        if self.db.autocommit or config.DRIVER == "sqlite2" or sys.version_info[0] == 3:
             c=self.db.cursor()
             for table in self.tables:
                 if self.usetables and table not in self.usetables:

--- a/tests/pydotest.rc
+++ b/tests/pydotest.rc
@@ -1,0 +1,6 @@
+# -*-python-*-
+
+#psycopg=dict(connectArgs=dict(dsn='user=pydotest dbname=pydotest host=localhost'))
+sqlite=dict(connectArgs=dict(database='/tmp/pydotest_sqlite.db'))
+sqlite2=dict(connectArgs=dict(database=':memory:'))
+mysql=dict(connectArgs=dict(db='pydotest', user='pydotest'))

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -3,12 +3,14 @@
 import sys
 import re
 import logging
+import os
 
 # munge sys.path
 
-sys.path.insert(0, '../src')
+_d = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(_d, '../src'))
 
-import config
+import config as _config
 from testingtesting import runNamespace, info, runModule, _defaultNamePat, _testsForModule
 from pydo import initAlias, delAlias, setLogLevel
 
@@ -24,20 +26,27 @@ from test_multifetch import *
 from test_operators import *
 
 if __name__=='__main__':
-    drivers, tags, pat, use_unit=config.readCmdLine(sys.argv[1:])
+    drivers, tags, pat, use_unit = _config.readCmdLine(sys.argv[1:])
     res=0
     import runtests
     for d, connectArgs in drivers.items():
+        _config.DRIVER = d
         initAlias(**connectArgs)
         curtags=list(tags)+[d]
+        # clean up existing sqlite db
+        if d.startswith('sqlite'):
+            _ca = connectArgs['connectArgs']
+            # print("d=%r _ca=%r" % (d, _ca))
+            db = _ca['database']
+            if db != ':memory:' and os.path.exists(db):
+                os.remove(db)
         if tags:
             info("testing with driver: %s, tags: %s", d, ", ".join(tags))
         else:
             info("testing with driver: %s", d)
-        config.DRIVER=d
         try:
             res |= runModule(runtests, curtags, pat, use_unit)
         finally:
             delAlias('pydotest')
-            del config.DRIVER
+            del _config.DRIVER
     sys.exit(res)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -349,11 +349,11 @@ def test_guess_columns1():
             connectionAlias='pydotest'
 
         cols=testclass.getColumns()
-
         uniq=testclass.getUniquenessConstraints()
         seq=testclass.getSequences()
         assert set(cols)==set(('id', 'x', 'y', 'z', 'r1', 'r2'))
-        assert list(seq.keys())==['id']
+        _sk = list(seq.keys())
+        assert _sk == ['id'], "seq.keys is %r" % _sk
         assert uniq==frozenset((frozenset(('r1', 'r2')),
                                 frozenset(('x',)),
                                 frozenset(('id',))))

--- a/tests/test_dbi.py
+++ b/tests/test_dbi.py
@@ -99,13 +99,13 @@ def test_swapConnection1():
 @tag(*dbitags)
 def test_pool1():
     stuff=D._aliases['pydotest'].copy()
-    D.initAlias('pydotestpool',
+    try:
+        D.initAlias('pydotestpool',
                 stuff['driver'],
                 stuff['connectArgs'],
                 D.ConnectionPool(max_poolsize=4, keep_poolsize=4),
                 stuff['verbose'])
-    db=D.getConnection('pydotestpool')
-    try:
+        db=D.getConnection('pydotestpool')
         assert len(db.pool._busy)==0
         assert len(db.pool._free)==0
         conn=db.conn
@@ -161,6 +161,7 @@ def test_pool2():
     # assertion means: no connection has been handed out
     # to a plural number of simultaneously active threads
     assert len(connids)== len(set(connids))
+    D.delAlias('pydotestpool')
 
 
 @tag(*dbitags)


### PR DESCRIPTION
* Fixed `auto_increment` handling in MySQL driver
* Fixed auto_commit in SQLite driver
* Fixes initAlias/delAlias issue with testing
  multiple drivers at once
* Fixed GH action to run unit-tests as PyDO likes
* bumped version to 2.0.5

Signed-off-by: Yurii Shestakov <yuriis@nvidia.com>